### PR TITLE
fix-intchange-sourcechange

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,22 +11,29 @@ The ansible module firewalld is used for the configuration.
 Role Variables
 --------------
 
-There are three sets of variables:
- - firewalld_zones
+There are four hashes:
+ - firewalld_zone
+ - firewalld_allow_sources
  - firewalld_allow_services
  - firewalld_allow_ports
-
 
 Values for firewalld_zones:
 
     firewalld_zones:
       zone: [zone]
-      source: <source IP/network>
-      interface: [interface]
       permanent: [True|False] (default: True)
-      state: [enabled|disabled] (default: enabled)
-      immediate: [True|False] (default: True)
+      state: [present|absent] (default: present)
+      interface: [interface]
 
+Values for firewalld_allow_sources:
+
+    firewalld_allow_services:
+      source: <service name>
+      zone: [zone]			(default: public)
+      permanent: [True|False]	(default: True)
+      state: [enabled|disabled]	(default: enabled)
+
+Only source is required!
 
 Values for firewalld_allow_services:
 
@@ -35,7 +42,6 @@ Values for firewalld_allow_services:
       zone: [zone]			(default: public)
       permanent: [True|False]	(default: True)
       state: [enabled|disabled]	(default: enabled)
-      immediate: [True|False] (default: True)
 
 Only service is required!
 
@@ -46,8 +52,8 @@ Values for firewalld_allow_ports:
       zone: [zone]			(default: public)
       permanent: [True|False]	(default: True)
       state: [enabled|disabled]	(default: enabled)
-      immediate: [True|False] (default: True)
 
+Only port is required!
 
 Example Playbook
 ----------------
@@ -55,10 +61,16 @@ Example Playbook
     - hosts: servers
       vars:
         firewalld_zones:
-            - { zone: "trusted", source: "192.168.1.1/24", interface: "eth0", state: "enabled", permanent: true, immediate: true }
+          - { zone: "internal", interface: "ens256", state: "present", permanent: true }
+          - { zone: "dmz", interface: "ens224", state: "present", permanent: true }
         firewalld_allow_services:
           - { service: "http" }
           - { service: "telnet", zone: "dmz", permanent: True, state: "disabled" }
+        firewalld_allow_ports:
+          - { port: "161/udp", zone: "internal", permanent: True, state: "enabled" }
+          - { port: "162/udp", zone: "internal", permanent: True, state: "enabled" }
+        firewalld_allow_sources:
+          - { source: 192.168.2.0/23, zone: "internal", permanent: True, state: "enabled" }
       roles:
         - mvarian.firewalld
 
@@ -71,8 +83,6 @@ Disable firewalld service example
           - { firewalld_disable: true }
       roles:
         - mvarian.firewalld
-
-
 
 License
 -------

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,3 +2,8 @@
 # 'service reload' was not always working, needs complete reload
 - name: firewalld complete reload
   command: firewall-cmd --complete-reload
+
+- name: firewalld complete restart
+  ansible.builtin.service:
+    name: firewalld
+    state: restarted

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
     group: root
     mode: 0644
   notify:
-    - firewalld complete reload
+    - "firewalld complete reload"
 
 - name: Ensure firewalld is running and enabled on boot
   service:
@@ -30,36 +30,61 @@
 
 - name: Configure firewalld zones from vars
   firewalld:
-      source={{ item.source }}
-      zone={{ item.zone }}
-      interface={{ item.interface }}
-      state={{ item.state | default ("enabled") }}
-      permanent={{ item.permanent | default (True) }}
-      immediate={{ item.immediate | default (True) }}
-  with_items: "{{ firewalld_zones }}"
-  notify: firewalld complete reload
+    zone: "{{ item.zone }}"
+    permanent: "{{ item.permanent | default (True) }}"
+    state: "{{ item.state | default (present) }}"
+  loop: "{{ firewalld_zones }}"
+  notify:
+    - "firewalld complete reload"
   when: firewalld_disable == false
+
+- meta: flush_handlers
+
+- name: set firewalld zone interfaces
+  shell: |
+    if [[ "$(/bin/firewall-cmd --get-zone-of-interface={{ item.interface }})" != "{{ item.zone }}" ]]
+    then
+      /bin/firewall-cmd --zone={{ item.zone }} --add-interface={{ item.interface }} --permanent && echo "changed"
+    fi
+  loop: "{{ firewalld_zones }}"
+  register: shell_result
+  changed_when: shell_result.stdout | join('') is search('changed')
+  notify:
+    - "firewalld complete restart"
+  tags: firewalld
+
+- name: Add firewalld rules for sources from vars
+  firewalld:
+    source: "{{ item.source }}"
+    zone: "{{ item.zone | default (public) }}"
+    permanent: "{{ item.permanent | default (True) }}"
+    state: "{{ item.state | default (enabled) }}"
+    immediate: "{{ item.immediate | default (True) }}"
+  loop: "{{ firewalld_allow_sources }}"
+  notify: 
+    - "firewalld complete restart"
+  when: firewalld_disable == false and item.source is defined
 
 - name: Add firewalld rules for services from vars
   firewalld:
     service: "{{ item.service }}"
-    zone: "{{ item.zone | default('public') }}"
-    permanent: "{{ item.permanent | default(True) }}"
-    state: "{{ item.state | default('enabled') }}"
-    immediate: "{{ item.immediate | default(True) }}"
-  with_items: "{{ firewalld_allow_services }}"
-  notify:
-    - firewalld complete reload
-  when: firewalld_disable == false
+    zone: "{{ item.zone | default (public) }}"
+    permanent: "{{ item.permanent | default (True) }}"
+    state: "{{ item.state | default (enabled) }}"
+    immediate: "{{ item.immediate | default (True) }}"
+  loop: "{{ firewalld_allow_services }}"
+  notify: 
+    - "firewalld complete restart"
+  when: firewalld_disable == false and item.service is defined
 
 - name: Add firewalld rules for ports from vars
   firewalld:
     port: "{{ item.port }}"
-    zone: "{{ item.zone | default('public') }}"
-    permanent: "{{ item.permanent | default(True) }}"
-    state: "{{ item.state | default('enabled') }}"
-    immediate: "{{ item.immediate | default(True) }}"
-  with_items: "{{ firewalld_allow_ports }}"
-  notify:
-    - firewalld complete reload
-  when: firewalld_disable == false
+    zone: "{{ item.zone | default (public) }}"
+    permanent: "{{ item.permanent | default (True) }}"
+    state: "{{ item.state | default (enabled) }}"
+    immediate: "{{ item.immediate | default (True) }}"
+  loop: "{{ firewalld_allow_ports }}"
+  notify: 
+    - "firewalld complete restart"
+  when: firewalld_disable == false and item.port is defined


### PR DESCRIPTION
tested on RHEL
- zone are created correctly
- interfaces are added to expected zone
- zone are modified to allow services, ports, from a source.
- firewalld_allow_sources, firewalld_allow_services, firewalld_allow_ports are not mandatory.