### PR TITLE
Fix module firewalld requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@ Uses firewalld on CentOS/Redhat 7 or Fedora 21/22 to configure the firewall zone
 Requirements
 ------------
 
-The ansible module firewalld is used for the configuration.
+The ansible firewalld module has been moved to the ansible.posix collection. This feature will be removed from community.general in version 2.0.0.
+
+If needed, install the ansible.posix collection:
+
+  ansible-galaxy collection install ansible.posix
 
 Role Variables
 --------------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Sean O'Keeffe
   description: A module to configure firewalld zones and rules. Forked from marcelnijenhof.firewalld.
   license: BSD
-  min_ansible_version: 1.4
+  min_ansible_version: 2.9
   platforms:
   - name: EL
     versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,7 @@
   when: firewalld_disable == true
 
 - name: Configure firewalld zones from vars
-  firewalld:
+  ansible.posix.firewalld:
     zone: "{{ item.zone }}"
     permanent: "{{ item.permanent | default (True) }}"
     state: "{{ item.state | default (present) }}"
@@ -54,7 +54,7 @@
   tags: firewalld
 
 - name: Add firewalld rules for sources from vars
-  firewalld:
+  ansible.posix.firewalld:
     source: "{{ item.source }}"
     zone: "{{ item.zone | default (public) }}"
     permanent: "{{ item.permanent | default (True) }}"
@@ -66,7 +66,7 @@
   when: firewalld_disable == false and item.source is defined
 
 - name: Add firewalld rules for services from vars
-  firewalld:
+  ansible.posix.firewalld:
     service: "{{ item.service }}"
     zone: "{{ item.zone | default (public) }}"
     permanent: "{{ item.permanent | default (True) }}"
@@ -78,7 +78,7 @@
   when: firewalld_disable == false and item.service is defined
 
 - name: Add firewalld rules for ports from vars
-  firewalld:
+  ansible.posix.firewalld:
     port: "{{ item.port }}"
     zone: "{{ item.zone | default (public) }}"
     permanent: "{{ item.permanent | default (True) }}"
@@ -90,7 +90,7 @@
   when: firewalld_disable == false and item.port is defined
 
 - name: Configure firewalld target zones from vars
-  firewalld:
+  ansible.posix.firewalld:
     zone: "{{ item.zone }}"
     target: "{{ item.target }}"
     state: "{{ item.state | default (present) }}"


### PR DESCRIPTION
Modification of the minimal version needed and modification to use the ansible.posix collection. The modification of target parameter failed if the firewalld module of community.general is used (it's deprecated).